### PR TITLE
fix(release): Add required permissions for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The release workflow was failing with 403 error because the default GITHUB_TOKEN didn't have sufficient permissions to create releases.

Added permissions:
- contents: write (required for creating releases)
- discussions: write (optional, for release discussions)

This resolves the 'Resource not accessible by integration' error.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Testing
- [ ] I have run the full test suite locally (`pytest tests/ -v`)
- [ ] I have tested the CLI installation (`./install-cli.sh`)
- [ ] I have tested the specific functionality changed
- [ ] I have added/updated tests for my changes
- [ ] All existing tests still pass

## Code Quality
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added docstrings to new functions/classes
- [ ] Breaking changes are documented
- [ ] Configuration changes are documented

## Checklist
- [ ] My code follows the trunk-based development workflow
- [ ] This PR is focused on a single feature/fix
- [ ] The PR title clearly describes the change
- [ ] I have linked relevant issues

## Additional Notes
Any additional information about the PR, deployment notes, etc.
