### PR TITLE
fix: Resolve template and kinds file paths relative to package directory

### DIFF
--- a/clab_tools/topology/generator.py
+++ b/clab_tools/topology/generator.py
@@ -24,8 +24,22 @@ class TopologyGenerator:
         kinds_file="supported_kinds.yaml",
     ):
         self.db = db_manager
-        self.template_file = Path(template_file)
-        self.kinds_file = Path(kinds_file)
+
+        # Resolve template file path relative to package root if it's a relative path
+        template_path = Path(template_file)
+        if not template_path.is_absolute():
+            # Get the package root directory (where the template should be)
+            package_root = Path(__file__).parent.parent.parent
+            template_path = package_root / template_file
+        self.template_file = template_path
+
+        # Resolve kinds file path relative to package root if it's a relative path
+        kinds_path = Path(kinds_file)
+        if not kinds_path.is_absolute():
+            # Get the package root directory (where the kinds file should be)
+            package_root = Path(__file__).parent.parent.parent
+            kinds_path = package_root / kinds_file
+        self.kinds_file = kinds_path
 
     def load_supported_kinds(self):
         """Load supported device kinds from YAML configuration file."""

--- a/tests/test_topology_generator.py
+++ b/tests/test_topology_generator.py
@@ -1,0 +1,125 @@
+"""Tests for topology generator functionality."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from clab_tools.topology.generator import TopologyGenerator
+
+
+class TestTopologyGenerator:
+    """Test cases for TopologyGenerator."""
+
+    @pytest.fixture
+    def mock_db_manager(self):
+        """Create a mock database manager."""
+        mock_db = Mock()
+        return mock_db
+
+    def test_template_path_resolution_relative(self, mock_db_manager):
+        """Test that relative template paths are resolved relative to package root."""
+        generator = TopologyGenerator(
+            mock_db_manager,
+            template_file="topology_template.j2",
+            kinds_file="supported_kinds.yaml",
+        )
+
+        # Template file should be resolved to package root
+        expected_template_path = Path(__file__).parent.parent / "topology_template.j2"
+        assert generator.template_file == expected_template_path
+
+        # Kinds file should be resolved to package root
+        expected_kinds_path = Path(__file__).parent.parent / "supported_kinds.yaml"
+        assert generator.kinds_file == expected_kinds_path
+
+    def test_template_path_resolution_absolute(self, mock_db_manager):
+        """Test that absolute template paths are preserved."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            template_path = Path(temp_dir) / "custom_template.j2"
+            kinds_path = Path(temp_dir) / "custom_kinds.yaml"
+
+            generator = TopologyGenerator(
+                mock_db_manager,
+                template_file=str(template_path),
+                kinds_file=str(kinds_path),
+            )
+
+            # Absolute paths should be preserved
+            assert generator.template_file == template_path
+            assert generator.kinds_file == kinds_path
+
+    def test_template_loading_from_different_dir(self, mock_db_manager):
+        """Test template loading when script runs from different directory."""
+        generator = TopologyGenerator(mock_db_manager)
+
+        # Mock the database methods
+        mock_db_manager.get_all_nodes.return_value = [
+            ("test_node", "test_kind", "192.168.1.1")
+        ]
+        mock_db_manager.get_all_connections.return_value = []
+        mock_db_manager.save_topology_config.return_value = None
+
+        # Change to a different directory temporarily
+        original_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.chdir(temp_dir)
+
+                # Verify the template file path is still correctly resolved
+                package_root = Path(__file__).parent.parent
+                expected_template = package_root / "topology_template.j2"
+                assert generator.template_file == expected_template
+
+                # The template file should exist (tests path resolution)
+                assert (
+                    generator.template_file.exists()
+                ), f"Template file not found at {generator.template_file}"
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_kinds_file_loading_from_different_dir(self, mock_db_manager):
+        """Test kinds file loading when script runs from different directory."""
+        generator = TopologyGenerator(mock_db_manager)
+
+        # Change to a different directory temporarily
+        original_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.chdir(temp_dir)
+
+                # Verify the kinds file path is correctly resolved
+                package_root = Path(__file__).parent.parent
+                expected_kinds = package_root / "supported_kinds.yaml"
+                assert generator.kinds_file == expected_kinds
+
+                # The kinds file should exist (tests path resolution)
+                assert (
+                    generator.kinds_file.exists()
+                ), f"Kinds file not found at {generator.kinds_file}"
+
+        finally:
+            os.chdir(original_cwd)
+
+    def test_load_supported_kinds_with_resolved_path(self, mock_db_manager):
+        """Test loading supported kinds with properly resolved path."""
+        generator = TopologyGenerator(mock_db_manager)
+
+        # Change to a different directory to simulate the original issue
+        original_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                os.chdir(temp_dir)
+
+                # Should not raise FileNotFoundError (path resolved correctly)
+                kinds = generator.load_supported_kinds()
+
+                # Should return either the loaded kinds or defaults, not an error
+                assert isinstance(kinds, dict)
+                assert len(kinds) > 0
+
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
- Fix TopologyGenerator to resolve relative template and kinds file paths relative to the package root directory instead of current working directory
- This allows the script to be executed from any directory without template file path errors
- Add comprehensive tests for path resolution behavior including:
  * Relative path resolution to package root
  * Absolute path preservation
  * Cross-directory execution testing
  * Template and kinds file loading from different directories

Fixes the error: 'topology_template.j2' not found in search path: '.' when running clab-tools from directories other than the package root.

Test Results:
- All 53 tests passing (48 existing + 5 new path resolution tests)
- Verified script works correctly when executed from different directories

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Testing
- [ ] I have run the full test suite locally (`pytest tests/ -v`)
- [ ] I have tested the CLI installation (`./install-cli.sh`)
- [ ] I have tested the specific functionality changed
- [ ] I have added/updated tests for my changes
- [ ] All existing tests still pass

## Code Quality
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added docstrings to new functions/classes
- [ ] Breaking changes are documented
- [ ] Configuration changes are documented

## Checklist
- [ ] My code follows the trunk-based development workflow
- [ ] This PR is focused on a single feature/fix
- [ ] The PR title clearly describes the change
- [ ] I have linked relevant issues

## Additional Notes
Any additional information about the PR, deployment notes, etc.
