### PR TITLE
fix: Remove virtual environment dependency from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,16 +34,17 @@ jobs:
       run: |
         pytest tests/ -v --cov=clab_tools --cov-report=term
 
-    - name: Test CLI installation
+    - name: Test CLI functionality
       run: |
-        chmod +x clab-tools.sh
-        chmod +x install-cli.sh
-        # Install CLI wrapper
-        ./install-cli.sh
-        # Test basic functionality with new command structure
-        clab-tools data import -n example_nodes.csv -c example_connections.csv
-        clab-tools data show
-        clab-tools topology generate -o release_test.yml --validate
+        # Test CLI directly using the installed package
+        python -m clab_tools.cli data import -n example_nodes.csv -c example_connections.csv
+        python -m clab_tools.cli data show
+        python -m clab_tools.cli topology generate -o release_test.yml --validate
+
+        # Test the main.py entry point as well
+        python clab_tools/main.py data import -n example_nodes.csv -c example_connections.csv --lab test-release
+        python clab_tools/main.py data show --lab test-release
+        python clab_tools/main.py topology generate -o release_test2.yml --lab test-release --validate
 
     - name: Extract version from tag
       id: version


### PR DESCRIPTION
- Replace install-cli.sh test with direct CLI testing using installed package
- Test both python -m clab_tools.cli and python clab_tools/main.py entry points
- Avoid virtual environment setup requirement in CI environment
- Use separate labs for testing to avoid data conflicts

This resolves the 'Virtual environment not found' error in the release workflow.

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Testing
- [ ] I have run the full test suite locally (`pytest tests/ -v`)
- [ ] I have tested the CLI installation (`./install-cli.sh`)
- [ ] I have tested the specific functionality changed
- [ ] I have added/updated tests for my changes
- [ ] All existing tests still pass

## Code Quality
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added docstrings to new functions/classes
- [ ] Breaking changes are documented
- [ ] Configuration changes are documented

## Checklist
- [ ] My code follows the trunk-based development workflow
- [ ] This PR is focused on a single feature/fix
- [ ] The PR title clearly describes the change
- [ ] I have linked relevant issues

## Additional Notes
Any additional information about the PR, deployment notes, etc.
