### PR TITLE
fix: Correct CLI option placement in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,10 @@ jobs:
         python -m clab_tools.cli data show
         python -m clab_tools.cli topology generate -o release_test.yml --validate
 
-        # Test the main.py entry point as well
-        python clab_tools/main.py data import -n example_nodes.csv -c example_connections.csv --lab test-release
-        python clab_tools/main.py data show --lab test-release
-        python clab_tools/main.py topology generate -o release_test2.yml --lab test-release --validate
+        # Test the main.py entry point with different lab
+        python clab_tools/main.py --lab test-release data import -n example_nodes.csv -c example_connections.csv
+        python clab_tools/main.py --lab test-release data show
+        python clab_tools/main.py --lab test-release topology generate -o release_test2.yml --validate
 
     - name: Extract version from tag
       id: version


### PR DESCRIPTION
- Move --lab option before subcommand (python main.py --lab test-release data import)
- Fix 'No such option: --lab' error in release testing
- Proper CLI argument order for testing different labs

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Performance improvement

## Testing
- [ ] I have run the full test suite locally (`pytest tests/ -v`)
- [ ] I have tested the CLI installation (`./install-cli.sh`)
- [ ] I have tested the specific functionality changed
- [ ] I have added/updated tests for my changes
- [ ] All existing tests still pass

## Code Quality
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Code follows the project style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas

## Documentation
- [ ] I have updated relevant documentation
- [ ] I have added docstrings to new functions/classes
- [ ] Breaking changes are documented
- [ ] Configuration changes are documented

## Checklist
- [ ] My code follows the trunk-based development workflow
- [ ] This PR is focused on a single feature/fix
- [ ] The PR title clearly describes the change
- [ ] I have linked relevant issues

## Additional Notes
Any additional information about the PR, deployment notes, etc.
